### PR TITLE
Implement `Hash`, `Eq`, and `Ord` for `PathScheme`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pathscheme"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/olix0r/pathscheme"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,16 @@
 //!     .is_empty());
 //! ```
 //!
+//! Literal path matching is case-sensitive:
+//!
+//! ```
+//! # use pathscheme::*;
+//! assert!("/users/new".parse::<PathScheme>()
+//!     .unwrap()
+//!     .matches("/users/New")
+//!     .is_none());
+//! ```
+//!
 //! Or they may capture path segments:
 //!
 //! ```
@@ -62,7 +72,7 @@ use indexmap::IndexMap;
 use std::{fmt::Write, sync::Arc};
 
 /// Describes a path scheme that may match one or paths.
-#[derive(Clone, Debug, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PathScheme {
     elements: Vec<Element>,
 }
@@ -88,7 +98,7 @@ pub enum ParseError {
     TrailingSlash,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Eq, Ord)]
 enum Element {
     Literal(Arc<str>),
     Identifier(Arc<str>),


### PR DESCRIPTION
`PathScheme` instances may not currently be used in map keys. This is an
unnecessary limitation.

This change also documents that path matching is case-sensitive.